### PR TITLE
Add support for chainId & not-officially-supported methods

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,7 @@ export enum RPCMethodName {
   GET_FILTER_CHANGES = 'eth_getFilterChanges',
   GET_FILTER_LOGS = 'eth_getFilterLogs',
   GET_LOGS = 'eth_getLogs',
+  CHAIN_ID = 'eth_chainId',
 }
 
 export type RPCMethodNameType = `${RPCMethodName}`;
@@ -174,6 +175,7 @@ type RPCMethodNoParams =
   | `${RPCMethodName.BLOCK_NUMBER}`
   | `${RPCMethodName.NEW_BLOCK_FILTER}`
   | `${RPCMethodName.NEW_PENDING_TRANSACTION_FILTER}`
+  | `${RPCMethodName.CHAIN_ID}`
 
 export type RPCMethodParams<T> = T extends RPCMethodNoParams
   ? undefined

--- a/src/types.ts
+++ b/src/types.ts
@@ -264,6 +264,7 @@ export type RPCResponse<T> = T extends `${RPCMethodName.NET_LISTENING}`
       | `${RPCMethodName.NEW_FILTER}`
       | `${RPCMethodName.NEW_BLOCK_FILTER}`
       | `${RPCMethodName.NEW_PENDING_TRANSACTION_FILTER}`
+      | `${RPCMethodName.CHAIN_ID}`
   ? HexString
   : T extends `${RPCMethodName.GET_FILTER_CHANGES}`
   ? HexString[]

--- a/src/wally-connector.ts
+++ b/src/wally-connector.ts
@@ -285,7 +285,11 @@ class WallyConnector {
         'params' in req ? (req.params as RPCMethodParams<T>) : undefined
       );
     } else {
-      throw new Error(`Method ${req.method} is unsupported at this time.`);
+      console.error(`Method: ${req.method} is not officially supported by wally at this time, use at your own risk! Contact wally support to get it prioritized.`)
+      return this.requestRPC(
+        req.method as any,
+        'params' in req ? (req.params as any) : undefined
+      );
     }
   }
 


### PR DESCRIPTION
Web3Modal needed `eth_chainID`, even though it's not in [the spec](https://ethereum.org/en/developers/docs/apis/json-rpc/#json-rpc-methods) smh

Also made it possible to just pass through arbitrary methods with an error disclaimer so that we don't have to keep adding individual methods.  